### PR TITLE
feat: Create a static website with MkDocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: deploy-docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp*
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to the Cheatsheet Website
+
+This website contains a collection of useful commands and scripts for DevOps, SRE, Platform, Infra, and Cloud engineers.
+
+You can use the navigation on the left to browse the different cheatsheets and scripts.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,18 @@
+site_name: Cheatsheet
+theme:
+  name: material
+plugins:
+  - exclude:
+      glob:
+        - "utils/aws-scripts/**"
+nav:
+  - Home: index.md
+  - Cheatsheets:
+    - Bash Profile: bash_profile.md
+    - Carvel: carvel_commands.md
+    - Docker & Containerd: docker_containerd_commands.md
+    - Git: git_commands.md
+    - Helm: helm_commands.md
+    - Kubectl: kubectl_commands.md
+    - Linux: linux_commands.md
+    - SaltStack: saltstack_commands.md


### PR DESCRIPTION
This commit introduces a static website generated with MkDocs to display the markdown documents in a more readable and searchable format.

The changes include:
- Installing MkDocs, the Material for MkDocs theme, and the mkdocs-exclude plugin.
- Initializing a new MkDocs project.
- Organizing all markdown files into the `docs` directory.
- Configuring the website with a site name, theme, and navigation structure in `mkdocs.yml`.
- Excluding the `aws-scripts` directory from the build.
- Adding a GitHub Actions workflow to automatically build and deploy the website to GitHub Pages.

This will make the cheatsheets and documentation more accessible to users.